### PR TITLE
Add project docs and GitHub workflow scaffolding

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Linked Issue
+
+- Closes #
+
+## What Changed
+
+- 
+
+## Screenshots
+
+- N/A
+
+## How To Test
+
+1. 
+
+## Follow-Up Work
+
+- None
+
+## Checklist
+
+- [ ] Build passes
+- [ ] Relevant tests pass
+- [ ] Manual test steps are included
+- [ ] UI screenshots are included when applicable
+- [ ] Docs updated if behavior or contracts changed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## GatorGoods
+
+Canonical project/planning docs now live under [`docs/`](docs/):
+
+- [`docs/project-status.md`](docs/project-status.md) - current scope, issue map, milestones, and blockers
+- [`docs/architecture.md`](docs/architecture.md) - routes, auth rules, data model, and API contracts
+- [`docs/evaluation-plan.md`](docs/evaluation-plan.md) - study conditions, tasks, metrics, and data collection
+- [`docs/demo-runbook.md`](docs/demo-runbook.md) - final demo/video walkthrough and fallback plan
+- [`docs/workflow.md`](docs/workflow.md) - issue, branch, PR, and definition-of-done rules
+
+The older `.cursor/plans/*.plan.md` files are preserved for history but are now superseded by the docs above.
+
 ## GatorGoods Dev Setup
 
 This project is a React frontend (Create React App) with an Express + MongoDB backend.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,173 @@
+# Architecture
+
+This document defines the intended product architecture for the current implementation pass.
+
+## Product Rules
+
+- Browsing listings, item pages, and public profiles is public
+- Creating listings, sending offers, messaging, reporting, reviewing, and editing profile/listing data requires a signed-in Clerk user
+- The backend must derive the acting user from verified Clerk auth rather than trusting client-submitted user IDs
+- Email addresses and other private account data must never be exposed on public surfaces
+
+## Route Map
+
+- `/` - landing page
+- `/listings` - public marketplace feed
+- `/items/:id` - public item detail page
+- `/login` - Clerk sign-in
+- `/signup` - Clerk sign-up
+- `/create` - protected create/edit listing flow
+- `/offers` - protected buyer/seller offer inbox
+- `/messages` - protected conversation list
+- `/messages/:conversationId` - protected thread view
+- `/transactions` - protected transaction list
+- `/transactions/:id` - protected transaction detail view
+- `/profile/:clerkUserId` - public seller profile
+- `/profile/me` - private profile and listing management view
+
+## Data Model
+
+### Profiles
+
+- `clerkUserId`
+- `email`
+- `displayName`
+- `avatarUrl`
+- `bannerUrl`
+- `bio`
+- `instagramUrl`
+- `linkedinUrl`
+- `ufVerified`
+- `trustMetrics`
+- `completedSales`
+- `completedPurchases`
+- `createdAt`
+- `updatedAt`
+
+### Listings
+
+- `sellerClerkUserId`
+- `sellerDisplayName`
+- `title`
+- `price`
+- `condition`
+- `location`
+- `imageUrl`
+- `description`
+- `details`
+- `status` = `active | reserved | sold | archived`
+- `createdAt`
+- `updatedAt`
+
+### Offers
+
+- `listingId`
+- `buyerClerkUserId`
+- `sellerClerkUserId`
+- `conversationId`
+- `offeredPrice`
+- `meetupLocation`
+- `meetupWindow`
+- `paymentMethod` = `cash | externalApp | gatorgoodsEscrow`
+- `escrowMode` = `none | deposit | full`
+- `message`
+- `status` = `pending | countered | accepted | declined | cancelled | convertedToTransaction`
+- `createdAt`
+- `updatedAt`
+
+### Conversations
+
+- `participantIds`
+- `linkedListingIds`
+- `activeListingId`
+- `lastMessageAt`
+- `lastReadAtByUser`
+- `createdAt`
+- `updatedAt`
+
+### Messages
+
+- `conversationId`
+- `senderClerkUserId`
+- `body`
+- `attachedListingId`
+- `createdAt`
+
+### Transactions
+
+- `offerId`
+- `listingId`
+- `conversationId`
+- `buyerClerkUserId`
+- `sellerClerkUserId`
+- `paymentMethod`
+- `escrowMode`
+- `escrowAmount`
+- `buyerPin`
+- `sellerPin`
+- `buyerEnteredSellerPin`
+- `sellerEnteredBuyerPin`
+- `status` = `scheduled | awaitingEscrow | escrowHeld | pinPending | confirmed | completed | cancelled | refunded | noShow | rescheduled`
+- `createdAt`
+- `updatedAt`
+
+### Reviews
+
+- `transactionId`
+- `reviewerClerkUserId`
+- `revieweeClerkUserId`
+- `outcome` = `completed | rescheduled | noShow`
+- `onTime`
+- `communicationGood`
+- `feltSafe`
+- `itemAsDescribed`
+- `comment`
+- `createdAt`
+
+### Reports
+
+- `reporterClerkUserId`
+- `targetType` = `listing | user | message`
+- `targetId`
+- `reason`
+- `details`
+- `status`
+- `createdAt`
+
+## Reputation Rules
+
+- `Reliability`, `Accuracy`, and `Responsiveness` are percent-based metrics
+- Metrics should be computed from recent confirmed transactions rather than inflated lifetime totals
+- Item pages, offer surfaces, and public profiles should expose trust information early in the flow
+
+## API Shape
+
+- `POST /api/profiles/sync`
+- `GET /api/profiles/:clerkUserId`
+- `GET /api/listings`
+- `GET /api/listings/:id`
+- `POST /api/listings`
+- `PATCH /api/listings/:id`
+- `DELETE /api/listings/:id`
+- `POST /api/listings/:id/offers`
+- `GET /api/offers?role=buyer|seller`
+- `PATCH /api/offers/:id`
+- `GET /api/conversations`
+- `POST /api/conversations`
+- `GET /api/conversations/:id/messages`
+- `POST /api/conversations/:id/messages`
+- `GET /api/transactions`
+- `GET /api/transactions/:id`
+- `POST /api/transactions/:id/escrow`
+- `POST /api/transactions/:id/pin-verify`
+- `POST /api/transactions/:id/confirm`
+- `POST /api/reviews`
+- `GET /api/reviews/summary/:clerkUserId`
+- `POST /api/reports`
+
+## Key Implementation Decisions
+
+- Clerk remains the identity provider; there is no custom auth rewrite
+- Escrow is simulated for HCI and trust-flow purposes; no real payment processor is required for the class deliverable
+- Messaging is people-first with attached item context, not one thread per item
+- REST plus polling is acceptable for v1; websockets are not required to complete the project

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -1,0 +1,57 @@
+# Demo Runbook
+
+Use this runbook for the final implementation video, class demo, and fallback live walkthroughs.
+
+## Pre-Demo Checklist
+
+- Verify `.env.local` contains the correct Clerk publishable key
+- Verify backend `.env` contains a working MongoDB connection string
+- Start frontend and backend successfully
+- Confirm demo listings, offers, and transaction data exist
+- Confirm all demo accounts can sign in
+
+## Required Demo Roles
+
+- Seller
+- Buyer
+- Backup buyer for reservation/conflict scenarios
+
+## Recommended Demo Flow
+
+1. Show the public landing page and marketplace feed
+2. Show filtering and campus-aware listing discovery
+3. Open a public item detail page and call out visible trust signals
+4. Sign in as a buyer and submit a structured offer
+5. Switch to the seller and review offers in the inbox
+6. Accept the offer and move into the conversation thread
+7. Show the transaction detail view
+8. If using escrow, show the held payment state and PIN verification
+9. Complete the transaction and submit structured reviews
+10. Revisit the seller profile to show updated trust metrics
+
+## Video Capture Notes
+
+- Keep one seeded transaction in progress so the escrow/PIN flow can be shown quickly
+- Keep one listing in `reserved` state and one in `sold` state for feed examples
+- Avoid live data creation during the video unless the step is central to the story
+
+## Fallback Plan
+
+If one part of the live flow breaks:
+
+- Fall back to the seeded data path rather than debugging on camera
+- Skip nonessential profile-editing details before skipping trust, offer, messaging, or transaction flows
+- If escrow is unstable, still show transaction status and explain that the escrow state is simulated in-app
+
+## Manual Smoke Test Before Recording
+
+- Public browse works
+- Sign-in works
+- Create listing works
+- Item detail page loads
+- Offer creation works
+- Seller inbox shows the offer
+- Messaging thread opens with listing context
+- Transaction detail page loads
+- Review submission works
+- Trust metrics render on the profile

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -1,0 +1,73 @@
+# Evaluation Plan
+
+This document defines the intended study setup for the implementation and final evaluation phases.
+
+## Study Goal
+
+Measure whether GatorGoods improves trust formation and transaction coordination compared to a more generic marketplace-style flow.
+
+## Conditions
+
+### Baseline
+
+- Simpler negotiation flow
+- Reduced trust context
+- Minimal item-context guidance in conversations
+- No simulated escrow/PIN interaction
+
+### Enhanced
+
+- Offer-first negotiation
+- Seller trust metrics visible early
+- Item-context messaging
+- Optional simulated escrow and dual PIN release
+
+## Core Tasks
+
+1. Find a listing that matches a campus pickup need
+2. Decide whether the seller appears trustworthy
+3. Send or respond to a structured offer
+4. Coordinate the exchange inside the app
+5. Complete the transaction flow and leave structured feedback
+
+## Primary Metrics
+
+- Task completion rate
+- Task completion time
+- Self-reported trust/confidence rating
+- Self-reported ease of coordination
+- Qualitative feedback on safety and convenience
+
+## Secondary Metrics
+
+- Whether participants understood the trust metrics
+- Whether item-context messaging reduced confusion
+- Whether escrow/PIN steps felt helpful or too heavy
+
+## Participants
+
+- UF students or close proxies who match the target audience
+- Participants should use the app in a browser without installing anything
+
+## Data To Collect
+
+- Condition used
+- Task start and end times
+- Success/failure per task
+- Confidence/trust rating after key tasks
+- Brief post-task comments
+- Final interview or survey feedback
+
+## Demo And Study Accounts
+
+Minimum roles needed before running the final study:
+
+- Seller account
+- Buyer account
+- Second buyer or backup account for conflicting-offer and reservation flows
+
+## Risks To Watch
+
+- If the baseline and enhanced conditions diverge too much, the comparison becomes muddy
+- If demo data is stale, study participants may waste time on setup rather than evaluating the product
+- If trust metrics are not understandable at a glance, the proposed HCI contribution weakens

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,0 +1,87 @@
+# Project Status
+
+This file is the current source of truth for implementation scope and issue organization.
+
+GitHub parent tracker: [#26 Track proposal-aligned implementation through final submission](https://github.com/Maykur/GatorGoods/issues/26)
+
+## Current Goal
+
+Ship a proposal-aligned UF marketplace that supports:
+
+- UF-only authenticated participation for creating listings, offers, messaging, and reviews
+- Public browsing of listings, item detail pages, and seller trust signals
+- Offer-first negotiation with structured payment and meetup inputs
+- People-first messaging with item context attached to the thread
+- Transaction tracking, optional simulated escrow, and dual PIN release
+- Structured reviews and percent-based trust metrics
+
+## Delivery Dates
+
+- Core marketplace target: April 6, 2026
+- Negotiation and messaging target: April 11, 2026
+- Trust and transactions target: April 18, 2026
+- Evaluation-ready target: April 20, 2026
+- Final submission target: April 22, 2026
+
+## Active Milestones
+
+- `Core Marketplace`
+- `Negotiation + Messaging`
+- `Trust + Transactions`
+- `Evaluation Ready`
+- `Final Submission`
+
+## Issue Map
+
+### Foundation
+
+- [#11 Integrate open PRs and normalize app foundations](https://github.com/Maykur/GatorGoods/issues/11)
+- [#12 Add backend Clerk auth and marketplace profile sync](https://github.com/Maykur/GatorGoods/issues/12)
+- [#13 Normalize listing schema and enforce listing ownership](https://github.com/Maykur/GatorGoods/issues/13)
+- [#14 Replace base64 listing images with multipart uploads](https://github.com/Maykur/GatorGoods/issues/14)
+
+### Marketplace
+
+- [#15 Build the public marketplace feed with campus-aware discovery](https://github.com/Maykur/GatorGoods/issues/15)
+- [#16 Rebuild create/edit listing flow and seller listing management](https://github.com/Maykur/GatorGoods/issues/16)
+- [#17 Ship the public item detail page with seller trust surfaces](https://github.com/Maykur/GatorGoods/issues/17)
+
+### Offers And Messaging
+
+- [#18 Implement structured offer-first creation and listing reservation](https://github.com/Maykur/GatorGoods/issues/18)
+- [#19 Build the buyer/seller offers inbox](https://github.com/Maykur/GatorGoods/issues/19)
+- [#20 Implement people-first messaging with attached item context](https://github.com/Maykur/GatorGoods/issues/20)
+
+### Transactions And Reputation
+
+- [#21 Add transaction records and transaction detail views](https://github.com/Maykur/GatorGoods/issues/21)
+- [#22 Implement simulated escrow and dual PIN release](https://github.com/Maykur/GatorGoods/issues/22)
+- [#23 Add structured reviews and percent-based reputation metrics](https://github.com/Maykur/GatorGoods/issues/23)
+- [#24 Build public/private profile pages with trust context](https://github.com/Maykur/GatorGoods/issues/24)
+
+### Evaluation And Submission
+
+- [#25 Prepare study mode, demo data, and stronger test coverage](https://github.com/Maykur/GatorGoods/issues/25)
+
+## Recommended Build Order
+
+`#11 -> #12 -> #13/#14 -> #15/#16/#17 -> #18/#19/#20 -> #21/#22 -> #23/#24 -> #25`
+
+## Blockers
+
+- Shared Clerk configuration must remain available to the team
+- Shared MongoDB connection must remain available to the team
+- Demo/study accounts need to exist before the final evaluation and recording pass
+
+## Ownership Rule
+
+- Every implementation issue should have exactly one owner before it moves to `In Progress`
+- Helper contributors are fine, but one person owns merge readiness and follow-up cleanup
+
+## Superseded Planning Docs
+
+The following repo-local planning docs are historical references, not the current source of truth:
+
+- `.cursor/plans/gatorgoods_creative_design_ideas_0b330e0f.plan.md`
+- `.cursor/plans/gatorgoods_implementation_plan_b1200267.plan.md`
+- `.cursor/plans/next-steps-without-backend-access_d0fc09f5.plan.md`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,70 @@
+# Workflow
+
+This document defines the working rules for implementing and reviewing GatorGoods.
+
+## Unit Of Work
+
+- One issue = one branch = one PR
+- Every implementation issue should have exactly one owner before work starts
+- Parallel work is fine as long as branches do not fight over the same files without coordination
+
+## Branch Naming
+
+Use:
+
+- `feat/<issue-number>-<short-slug>`
+- `fix/<issue-number>-<short-slug>`
+- `chore/<issue-number>-<short-slug>`
+
+Examples:
+
+- `feat/18-structured-offers`
+- `feat/20-contextual-messaging`
+- `chore/25-evaluation-readiness`
+
+## PR Titles
+
+Start PR titles with the issue number.
+
+Examples:
+
+- `[#18] Implement structured offer-first creation and listing reservation`
+- `[#23] Add structured reviews and percent-based reputation metrics`
+
+## Status Flow
+
+- `Ready`
+- `In Progress`
+- `Blocked`
+- `In Review`
+- `Done`
+
+Use issue comments, assignment, labels, and linked PRs to keep the status visible.
+
+## Definition Of Done
+
+Before closing a feature issue:
+
+- Relevant code is merged
+- Build and relevant tests pass
+- Manual test steps are documented in the PR
+- Screenshots are included for meaningful UI changes
+- Follow-up work is split into a new issue instead of hidden in review comments
+- Docs are updated if routes, contracts, or product behavior changed
+
+## Labels
+
+Keep labels lightweight and consistent:
+
+- Area labels for subsystem ownership
+- Type labels for feature, bug, and chore work
+- Priority labels for sequencing
+- `blocked` only when an issue cannot move without another dependency
+
+## Milestones
+
+- `Core Marketplace`
+- `Negotiation + Messaging`
+- `Trust + Transactions`
+- `Evaluation Ready`
+- `Final Submission`


### PR DESCRIPTION
## Summary
Adds a lightweight project-organization layer to make the repo and GitHub issues easier to work from so we can finish the project quickly

## What Changed
- added a `docs/` source-of-truth set for project status, architecture, evaluation planning, demo steps, and workflow
- updated the README to point to the new docs
- added a PR template to standardize future pull requests

## Why
The repo had implementation issues and planning context spread across GitHub issues, older plan files, and ad hoc notes. This PR centralizes the current working docs and gives the team a clearer workflow for issue -> branch -> PR execution.

## Testing
- not run; docs and project-structure changes only
