### PR TITLE
moved favorite items to a dedicated page and main nav

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { CreateListingPage } from './pages/CreateListingPage';
 import { OffersPage } from './pages/OffersPage';
 import { MessagesPage } from './pages/MessagesPage';
 import { ChatThreadPage } from './pages/ChatThreadPage';
+import { FavoritesPage } from './pages/FavoritesPage';
 import { ProfilePage } from './pages/ProfilePage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { ItemPage } from './pages/ItemPage';
@@ -66,6 +67,14 @@ function App() {
                   element={
                     <ProtectedRoute>
                       <ChatThreadPage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/favorites"
+                  element={
+                    <ProtectedRoute>
+                      <FavoritesPage />
                     </ProtectedRoute>
                   }
                 />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -143,6 +143,10 @@ jest.mock("./pages/ProfilePage", () => ({
   ProfilePage: () => <div>Profile Page</div>,
 }));
 
+jest.mock("./pages/FavoritesPage", () => ({
+  FavoritesPage: () => <div>Favorites Page</div>,
+}));
+
 jest.mock("./pages/ItemPage", () => ({
   ItemPage: () => <div>Item Page</div>,
 }));
@@ -209,6 +213,14 @@ test("signed-out users are redirected away from offers", () => {
   expect(window.location.pathname).toBe("/login");
 });
 
+test("signed-out users are redirected away from favorites", () => {
+  window.history.pushState({}, "", "/favorites");
+
+  render(<App />);
+
+  expect(window.location.pathname).toBe("/login");
+});
+
 test("signed-out users can continue through nested login routes", () => {
   window.history.pushState({}, "", "/login/factor-one");
 
@@ -266,6 +278,20 @@ test("signed-in users can use the profile shortcut route", () => {
 
   expect(window.location.pathname).toBe("/profile/me");
   expect(screen.getByText("Profile Page")).toBeInTheDocument();
+});
+
+test("signed-in users can access the favorites route", () => {
+  setClerkState({
+    isSignedIn: true,
+    user: {
+      id: "user-1",
+    },
+  });
+  window.history.pushState({}, "", "/favorites");
+
+  render(<App />);
+
+  expect(screen.getByText("Favorites Page")).toBeInTheDocument();
 });
 
 test("unknown routes render the not-found page", () => {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -45,6 +45,7 @@ export function Layout() {
     { to: '/listings', label: 'Browse', icon: 'browse' },
     { to: '/messages', label: 'Messages', icon: 'messages' },
     { to: '/offers', label: 'Offers', icon: 'offers' },
+    { to: '/favorites', label: 'Favorites', icon: 'favorite' },
     { to: '/profile/me', label: 'Profile', icon: 'profile' },
   ] : [];
 
@@ -201,6 +202,10 @@ export function Layout() {
               <Link to="/messages" className="inline-flex items-center gap-2 hover:text-white">
                 <AppIcon icon="messages" className="text-[0.9em]" />
                 <span>Messages</span>
+              </Link>
+              <Link to="/favorites" className="inline-flex items-center gap-2 hover:text-white">
+                <AppIcon icon="favorite" className="text-[0.9em]" />
+                <span>Favorites</span>
               </Link>
             </Show>
           </div>

--- a/src/pages/FavoritesPage.js
+++ b/src/pages/FavoritesPage.js
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useUser } from '@clerk/react';
+import FavCard from '../components/ProfilePage/FavCard';
+import {
+  Button,
+  EmptyState,
+  ErrorBanner,
+  PageHeader,
+  Skeleton,
+  useConfirmDialog,
+  useToast,
+} from '../components/ui';
+import { toListingCardViewModel } from '../lib/viewModels';
+
+const API_BASE_URL = 'http://localhost:5000';
+
+function FavoritesSkeleton() {
+  return (
+    <section className="w-full space-y-6">
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-12 w-80" />
+        <Skeleton className="h-6 w-full max-w-2xl" />
+      </div>
+      <Skeleton className="h-32 rounded-[1.5rem]" />
+      <Skeleton className="h-32 rounded-[1.5rem]" />
+    </section>
+  );
+}
+
+async function readJson(response, fallbackMessage) {
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    throw new Error(data?.message || data?.error || fallbackMessage);
+  }
+
+  return data;
+}
+
+async function fetchOptionalItem(itemId) {
+  if (!itemId) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/items/${itemId}`);
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return response.json();
+  } catch (error) {
+    return null;
+  }
+}
+
+export function FavoritesPage() {
+  const { user } = useUser();
+  const { confirm } = useConfirmDialog();
+  const { showToast } = useToast();
+  const [favoriteItems, setFavoriteItems] = useState([]);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [activeActionId, setActiveActionId] = useState('');
+
+  const loadFavorites = useCallback(async () => {
+    if (!user?.id) {
+      throw new Error('Sign in to view your favorites.');
+    }
+
+    const profileResponse = await fetch(`${API_BASE_URL}/profile/${user.id}`);
+    const profileData = await readJson(profileResponse, 'Failed to load favorites');
+    const favoriteIds = Array.isArray(profileData.profile?.profileFavorites)
+      ? profileData.profile.profileFavorites
+      : [];
+    const favoriteResults = await Promise.allSettled(favoriteIds.map(fetchOptionalItem));
+
+    return favoriteResults
+      .map((result) => (result.status === 'fulfilled' ? result.value : null))
+      .filter(Boolean);
+  }, [user?.id]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        const favorites = await loadFavorites();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setFavoriteItems(favorites);
+        setError('');
+      } catch (loadError) {
+        if (isMounted) {
+          setFavoriteItems([]);
+          setError(loadError.message || 'Failed to load favorites');
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadFavorites]);
+
+  const favoriteCards = useMemo(
+    () =>
+      favoriteItems.map((item) => ({
+        ...toListingCardViewModel(item),
+        sellerId: item.userPublishingID || '',
+      })),
+    [favoriteItems]
+  );
+
+  const handleRemoveFavorite = useCallback(
+    async (listingId, listingTitle) => {
+      if (!user?.id) {
+        return;
+      }
+
+      const shouldRemove = await confirm({
+        title: 'Remove this favorite?',
+        description: `Take ${listingTitle} out of your saved listings.`,
+        confirmLabel: 'Remove favorite',
+      });
+
+      if (!shouldRemove) {
+        return;
+      }
+
+      try {
+        setActiveActionId(`favorite-${listingId}`);
+        const response = await fetch(`${API_BASE_URL}/user/${user.id}/fav/${listingId}`, {
+          method: 'DELETE',
+        });
+        await readJson(response, 'Failed to remove favorite');
+        const refreshedFavorites = await loadFavorites();
+        setFavoriteItems(refreshedFavorites);
+        showToast({
+          title: 'Favorite removed',
+          description: `${listingTitle} is no longer in your saved items.`,
+          variant: 'success',
+        });
+      } catch (favoriteError) {
+        showToast({
+          title: 'Unable to update favorites',
+          description: favoriteError.message || 'Try again in a moment.',
+          variant: 'danger',
+        });
+      } finally {
+        setActiveActionId('');
+      }
+    },
+    [confirm, loadFavorites, showToast, user?.id]
+  );
+
+  if (isLoading) {
+    return <FavoritesSkeleton />;
+  }
+
+  return (
+    <section className="w-full space-y-8">
+      <PageHeader
+        eyebrow="Favorites"
+        icon="favorite"
+        title="Your saved items"
+        description="Keep quick access to listings you want to revisit, compare, or message about later."
+        actions={
+          <Link to="/listings" className="no-underline">
+            <Button variant="secondary" size="sm" leadingIcon="browse">
+              Browse listings
+            </Button>
+          </Link>
+        }
+      />
+
+      {error ? (
+        <ErrorBanner
+          title="We couldn't load your favorites"
+          message={`${error}. Refresh and try again in a moment.`}
+        />
+      ) : null}
+
+      {!error && favoriteCards.length > 0 ? (
+        <FavCard
+          items={favoriteCards}
+          removingListingId={activeActionId.replace('favorite-', '')}
+          onRemoveFavorite={handleRemoveFavorite}
+        />
+      ) : null}
+
+      {!error && favoriteCards.length === 0 ? (
+        <EmptyState
+          icon="favorite"
+          title="No favorites saved yet"
+          description="Save listings you want to revisit and they will show up here."
+          action={
+            <Link to="/listings" className="no-underline">
+              <Button variant="secondary" leadingIcon="browse">Browse listings</Button>
+            </Link>
+          }
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/src/pages/FavoritesPage.test.js
+++ b/src/pages/FavoritesPage.test.js
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FavoritesPage } from './FavoritesPage';
+import { resetClerkState, setClerkState } from '../testUtils/mockClerk';
+
+const mockShowToast = jest.fn();
+const mockConfirm = jest.fn(() => Promise.resolve(true));
+
+jest.mock('@clerk/react', () => {
+  const { getClerkState } = require('../testUtils/mockClerk');
+
+  return {
+    useUser: () => getClerkState(),
+  };
+});
+
+jest.mock(
+  'react-router-dom',
+  () => {
+    const React = require('react');
+
+    return {
+      Link: ({ children, to, ...props }) => React.createElement('a', { href: to, ...props }, children),
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock('../components/ui', () => {
+  const actual = jest.requireActual('../components/ui');
+
+  return {
+    ...actual,
+    useToast: () => ({
+      showToast: mockShowToast,
+    }),
+    useConfirmDialog: () => ({
+      confirm: mockConfirm,
+    }),
+  };
+});
+
+function jsonResponse(body, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+beforeEach(() => {
+  resetClerkState();
+  setClerkState({
+    isSignedIn: true,
+    user: {
+      id: 'seller-1',
+    },
+  });
+  mockShowToast.mockReset();
+  mockConfirm.mockReset();
+  mockConfirm.mockResolvedValue(true);
+
+  global.fetch = jest.fn((url, options = {}) => {
+    if (url === 'http://localhost:5000/profile/seller-1') {
+      return jsonResponse({
+        profile: {
+          profileID: 'seller-1',
+          profileFavorites: ['item-2'],
+        },
+      });
+    }
+
+    if (url === 'http://localhost:5000/items/item-2') {
+      return jsonResponse({
+        _id: 'item-2',
+        itemName: 'Mini Fridge',
+        itemCost: '80',
+        itemCondition: 'Fair',
+        itemLocation: 'Broward Hall',
+        itemPicture: 'fridge.png',
+        itemCat: 'Home & Garden',
+        userPublishingID: 'seller-2',
+        userPublishingName: 'Seller Two',
+        status: 'active',
+      });
+    }
+
+    if (url === 'http://localhost:5000/user/seller-1/fav/item-2' && options.method === 'DELETE') {
+      return jsonResponse({ profileFavorites: [] });
+    }
+
+    throw new Error(`Unhandled fetch request: ${url}`);
+  });
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+test('loads and renders saved favorites on the dedicated page', async () => {
+  render(<FavoritesPage />);
+
+  expect(await screen.findByText('Mini Fridge')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /remove favorite/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /browse listings/i })).toHaveAttribute('href', '/listings');
+});
+
+test('removing a favorite refreshes the dedicated favorites page', async () => {
+  render(<FavoritesPage />);
+
+  fireEvent.click(await screen.findByRole('button', { name: /remove favorite/i }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:5000/user/seller-1/fav/item-2',
+      expect.objectContaining({
+        method: 'DELETE',
+      })
+    );
+  });
+
+  expect(mockShowToast).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Favorite removed',
+      variant: 'success',
+    })
+  );
+});

--- a/src/pages/ProfilePage.js
+++ b/src/pages/ProfilePage.js
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useUser } from '@clerk/react';
 import ItemCard from '../components/ProfilePage/ItemCard';
-import FavCard from '../components/ProfilePage/FavCard';
 import {
   AppIcon,
   Avatar,
@@ -26,10 +25,6 @@ import {
 } from '../lib/viewModels';
 
 const API_BASE_URL = 'http://localhost:5000';
-const OWNER_TABS = [
-  { id: 'listings', label: 'Active listings', icon: 'listing' },
-  { id: 'favorites', label: 'Favorites', icon: 'favorite' },
-];
 const REVIEW_OPTIONS = ['0', '1', '2', '3', '4', '5'];
 
 function getEditableProfileValues(profileHeader) {
@@ -83,24 +78,6 @@ async function readJson(response, fallbackMessage) {
   }
 
   return data;
-}
-
-async function fetchOptionalItem(itemId) {
-  if (!itemId) {
-    return null;
-  }
-
-  try {
-    const response = await fetch(`${API_BASE_URL}/items/${itemId}`);
-
-    if (!response.ok) {
-      return null;
-    }
-
-    return response.json();
-  } catch (error) {
-    return null;
-  }
 }
 
 function ProfileConnectorLinks({ profileHeader }) {
@@ -167,13 +144,11 @@ export function ProfilePage({ ownerView = false }) {
   const { confirm } = useConfirmDialog();
   const { showToast } = useToast();
   const [info, setInfo] = useState(null);
-  const [favoriteItems, setFavoriteItems] = useState([]);
   const [error, setError] = useState('');
   const [reviewError, setReviewError] = useState('');
   const [reviewScore, setReviewScore] = useState('');
   const [profileForm, setProfileForm] = useState(getEditableProfileValues(null));
   const [profileFormError, setProfileFormError] = useState('');
-  const [activeTab, setActiveTab] = useState('listings');
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmittingReview, setIsSubmittingReview] = useState(false);
   const [isSavingProfile, setIsSavingProfile] = useState(false);
@@ -186,34 +161,14 @@ export function ProfilePage({ ownerView = false }) {
     }
 
     const profileResponse = await fetch(`${API_BASE_URL}/profile/${profileId}`);
-    const profileData = await readJson(profileResponse, 'Failed to load profile');
-
-    if (!ownerView) {
-      return {
-        profileData,
-        favorites: [],
-      };
-    }
-
-    const favoriteIds = Array.isArray(profileData.profile?.profileFavorites)
-      ? profileData.profile.profileFavorites
-      : [];
-    const favoriteResults = await Promise.allSettled(favoriteIds.map(fetchOptionalItem));
-
-    return {
-      profileData,
-      favorites: favoriteResults
-        .map((result) => (result.status === 'fulfilled' ? result.value : null))
-        .filter(Boolean),
-    };
-  }, [ownerView, profileId]);
+    return readJson(profileResponse, 'Failed to load profile');
+  }, [profileId]);
 
   useEffect(() => {
     let isMounted = true;
 
     if (!profileId) {
       setInfo(null);
-      setFavoriteItems([]);
       setError(ownerView ? 'Sign in to manage your profile.' : 'Profile not found');
       setIsLoading(false);
       return undefined;
@@ -222,19 +177,17 @@ export function ProfilePage({ ownerView = false }) {
     const load = async () => {
       try {
         setIsLoading(true);
-        const { profileData, favorites } = await loadProfile();
+        const profileData = await loadProfile();
 
         if (!isMounted) {
           return;
         }
 
         setInfo(profileData);
-        setFavoriteItems(favorites);
         setError('');
       } catch (loadError) {
         if (isMounted) {
           setInfo(null);
-          setFavoriteItems([]);
           setError(loadError.message || 'Failed to load profile');
         }
       } finally {
@@ -257,14 +210,6 @@ export function ProfilePage({ ownerView = false }) {
   );
   const trustMetrics = useMemo(() => toTrustMetricsViewModel(info), [info]);
   const listingItems = useMemo(() => (info?.listings || []).map(toListingCardViewModel), [info]);
-  const favoriteCards = useMemo(
-    () =>
-      favoriteItems.map((item) => ({
-        ...toListingCardViewModel(item),
-        sellerId: item.userPublishingID || '',
-      })),
-    [favoriteItems]
-  );
   const canReview = Boolean(
     !ownerView &&
       isSignedIn &&
@@ -283,9 +228,8 @@ export function ProfilePage({ ownerView = false }) {
   }, [ownerView, profileHeader]);
 
   const refreshProfile = useCallback(async () => {
-    const { profileData, favorites } = await loadProfile();
+    const profileData = await loadProfile();
     setInfo(profileData);
-    setFavoriteItems(favorites);
   }, [loadProfile]);
 
   const handleDeleteListing = useCallback(
@@ -323,43 +267,6 @@ export function ProfilePage({ ownerView = false }) {
       }
     },
     [confirm, refreshProfile, showToast]
-  );
-
-  const handleRemoveFavorite = useCallback(
-    async (listingId, listingTitle) => {
-      const shouldRemove = await confirm({
-        title: 'Remove this favorite?',
-        description: `Take ${listingTitle} out of your saved listings.`,
-        confirmLabel: 'Remove favorite',
-      });
-
-      if (!shouldRemove || !profileId) {
-        return;
-      }
-
-      try {
-        setActiveActionId(`favorite-${listingId}`);
-        const response = await fetch(`${API_BASE_URL}/user/${profileId}/fav/${listingId}`, {
-          method: 'DELETE',
-        });
-        await readJson(response, 'Failed to remove favorite');
-        await refreshProfile();
-        showToast({
-          title: 'Favorite removed',
-          description: `${listingTitle} is no longer in your saved items.`,
-          variant: 'success',
-        });
-      } catch (favoriteError) {
-        showToast({
-          title: 'Unable to update favorites',
-          description: favoriteError.message || 'Try again in a moment.',
-          variant: 'danger',
-        });
-      } finally {
-        setActiveActionId('');
-      }
-    },
-    [confirm, profileId, refreshProfile, showToast]
   );
 
   const handleReviewSubmit = async (event) => {
@@ -470,7 +377,7 @@ export function ProfilePage({ ownerView = false }) {
         title={ownerView ? 'Manage your profile' : profileHeader?.displayName || 'Seller profile'}
         description={
           ownerView
-            ? 'Update your photo, bio, links, listings, and saved items in one place.'
+            ? 'Update your photo, bio, links, and listings from one place.'
             : 'See this seller\'s bio, links, and ratings before you decide to buy.'
         }
         actions={
@@ -644,62 +551,36 @@ export function ProfilePage({ ownerView = false }) {
 
           {ownerView ? (
             <Card className="space-y-6">
-              <div className="flex flex-wrap gap-2" role="tablist" aria-label="Profile content sections">
-                {OWNER_TABS.map((tab) => (
-                  <button
-                    key={tab.id}
-                    type="button"
-                    role="tab"
-                    aria-selected={activeTab === tab.id}
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`focus-ring rounded-full border px-4 py-2 text-sm font-semibold transition-colors ${
-                      activeTab === tab.id
-                        ? 'border-gatorOrange/50 bg-gatorOrange/15 text-white'
-                        : 'border-white/10 bg-white/5 text-app-soft hover:border-white/20 hover:text-white'
-                    }`}
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <AppIcon icon={tab.icon} className="text-[0.95em]" />
-                      <span>{tab.label}</span>
-                    </span>
-                  </button>
-                ))}
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-gatorOrange">
+                    <AppIcon icon="listing" className="text-sm" />
+                    <span>Active listings</span>
+                  </div>
+                  <p className="text-sm leading-7 text-app-soft">
+                    Manage your current listings.
+                  </p>
+                </div>
+                <Link to="/favorites" className="no-underline">
+                  <Button variant="secondary" leadingIcon="favorite">Open favorites</Button>
+                </Link>
               </div>
 
-              {activeTab === 'listings' ? (
-                listingItems.length > 0 ? (
-                  <ItemCard
-                    items={listingItems}
-                    isOwner
-                    deletingListingId={activeActionId.replace('delete-', '')}
-                    onDelete={handleDeleteListing}
-                  />
-                ) : (
-                  <EmptyState
-                    icon="createListing"
-                    title="No active listings yet"
-                    description="Create your first listing to start selling around campus."
-                    action={
-                      <Link to="/create" className="no-underline">
-                        <Button leadingIcon="createListing">Create listing</Button>
-                      </Link>
-                    }
-                  />
-                )
-              ) : favoriteCards.length > 0 ? (
-                <FavCard
-                  items={favoriteCards}
-                  removingListingId={activeActionId.replace('favorite-', '')}
-                  onRemoveFavorite={handleRemoveFavorite}
+              {listingItems.length > 0 ? (
+                <ItemCard
+                  items={listingItems}
+                  isOwner
+                  deletingListingId={activeActionId.replace('delete-', '')}
+                  onDelete={handleDeleteListing}
                 />
               ) : (
                 <EmptyState
-                  icon="favorite"
-                  title="No favorites saved yet"
-                  description="Save listings you want to revisit and they will show up here."
+                  icon="createListing"
+                  title="No active listings yet"
+                  description="Create your first listing to start selling around campus."
                   action={
-                    <Link to="/listings" className="no-underline">
-                      <Button variant="secondary" leadingIcon="browse">Browse listings</Button>
+                    <Link to="/create" className="no-underline">
+                      <Button leadingIcon="createListing">Create listing</Button>
                     </Link>
                   }
                 />

--- a/src/pages/ProfilePage.test.js
+++ b/src/pages/ProfilePage.test.js
@@ -158,7 +158,7 @@ test('signed-out users can view a public seller profile with trust metrics and c
   expect(screen.queryByRole('button', { name: /save profile changes/i })).not.toBeInTheDocument();
 });
 
-test('signed-in owners see their dashboard tabs, edit form, and saved favorites', async () => {
+test('signed-in owners see their listings dashboard, edit form, and favorites shortcut', async () => {
   setClerkState({
     isSignedIn: true,
     user: {
@@ -174,12 +174,8 @@ test('signed-in owners see their dashboard tabs, edit form, and saved favorites'
     expect(displayNameInput).toHaveValue('Seller One');
   });
   expect(screen.getByLabelText(/short bio/i)).toHaveValue('Selling a few trusted dorm essentials.');
-  expect(screen.getByRole('tab', { name: /favorites/i })).toBeInTheDocument();
-
-  fireEvent.click(screen.getByRole('tab', { name: /favorites/i }));
-
-  expect(await screen.findByText('Mini Fridge')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /remove favorite/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /open favorites/i })).toHaveAttribute('href', '/favorites');
+  expect(screen.getByText(/your saved items now live in the main favorites page/i)).toBeInTheDocument();
 });
 
 test('signed-in owners can save lightweight public profile edits', async () => {


### PR DESCRIPTION

## What Changed

- Added a dedicated favorites page for saved items
- Moved Favorites into the signed-in main navigation and footer shortcuts
- Reworked the owner profile page so it focuses on listings and links to the new favorites page instead of hiding favorites behind a profile tab
- Added route and page tests for the new favorites flow

## Screenshots

- 
<img width="1586" height="1246" alt="image" src="https://github.com/user-attachments/assets/c7466c45-8807-4071-9d46-448c9198836a" />

- 
<img width="1621" height="1054" alt="image" src="https://github.com/user-attachments/assets/4500a5f5-2d07-4ec3-84fa-607e42dfd86d" />



## How To Test

1. Sign in and confirm Favorites appears in the main nav.
2. Open /favorites and verify saved listings render with seller, item, and remove actions.
3. Remove a favorite and confirm it disappears from the page with a success toast.
4. Open /profile/me and verify the page now links to Favorites instead of showing a favorites tab.

## Checklist

- [ ] Build passes
- [ ] Relevant tests pass
- [ ] Manual test steps are included
- [x] UI screenshots are included when applicable
- [ ] Docs updated if behavior or contracts changed
